### PR TITLE
Fix bug when replacing a user's kek

### DIFF
--- a/src/fscrypt_utils.c
+++ b/src/fscrypt_utils.c
@@ -647,7 +647,7 @@ enum fscrypt_utils_status_t wrap_fscrypt_key(struct user_key_data_t *known_user,
             data_buffer = read_stored_data(cryptdata_path);
             if (data_buffer != NULL)
             {
-                entry_buffer = locate_matching_user(data_buffer, known_user);
+                entry_buffer = locate_matching_user(data_buffer, new_user);
             }
             break;
         case KEY_MODE_APPEND_USER:


### PR DESCRIPTION
KEY_MODE_REPLACE_USER would overwrite the known_user's cryptostore entry, rather than update the new_user's crypto entry, as intended. This is now resolved and the new_user's entry is overwritten.